### PR TITLE
feat!: remove deprecated `options.environment`

### DIFF
--- a/lib/dotenv-flow-webpack.js
+++ b/lib/dotenv-flow-webpack.js
@@ -15,12 +15,7 @@ class DotenvFlow extends DefinePlugin {
    * @param {boolean} [options.silent=false] - set to `true` to suppress all errors and warnings
    */
   constructor(options = {}) {
-    let node_env = options.node_env || process.env.NODE_ENV || options.default_node_env;
-
-    if (options.environment) {
-      console.warn('dotenv-flow-webpack: the `environment` option is deprecated, please use `node_env` instead'); // >>>
-      node_env = options.environment;
-    }
+    const node_env = options.node_env || process.env.NODE_ENV || options.default_node_env;
 
     const path = options.path || process.cwd();
     const system_vars = options.system_vars || options.systemvars || false; // allow `options.systemvars` for compatibility with dotenv-webpack's options


### PR DESCRIPTION
BREAKING CHANGES: previously deprecated `options.environment` has been removed, please use `options.node_env` instead.