### PR TITLE
feat(dotenv-flow-webpack): add `options.pattern` for customizing `.env*` files' naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,59 @@ With the `path` initialization option you can specify a path to `.env*` files di
 
 ```js
 new DotenvFlow({
-  path: '/path/to/env-files-dir'
+  path: './config'
 })
 ```
 
-If the option is not provided, the current working directory will be used.
+If the option is not provided, the current working directory is used.
+
+#### `pattern`
+###### Type: `string`
+###### Default: `'.env[.node_env][.local]'`
+
+Allows you to change the default `.env*` files' naming convention
+if you want to have a specific file naming structure for maintaining
+your environment variables' files.
+
+**Default Value**
+
+The default value `".env[.node_env][.local]"` makes *dotenv-flow-webpack*
+look up and load the following files in order:
+
+1. `.env`
+2. `.env.local`
+3. `.env.${NODE_ENV}`
+4. `.env.${NODE_ENV}.local`
+
+For example, when the `proess.env.NODE_ENV` (or `options.node_env`) is set to `"development"`,
+*dotenv-flow-webpack* will be looking for and parsing (if found) the following files:
+
+1. `.env`
+2. `.env.local`
+3. `.env.development`
+4. `.env.development.local`
+
+**Custom Pattern**
+
+Here is a couple of examples of customizing the `.env*` files naming convention:
+
+For example, if you set the pattern to `".env/[local/]env[.node_env]"`,
+*dotenv-flow-webpack* will look for these files instead:
+
+1. `.env/env`
+2. `.env/local/env`
+3. `.env/env.development`
+4. `.env/local/env.development`
+
+… or if you set the pattern to `".env/[.node_env/].env[.node_env][.local]"`,
+the plugin will try to find and parse:
+
+1. `.env/.env`
+2. `.env/.env.local`
+3. `.env/development/.env.development`
+4. `.env/development/.env.development.local`
+
+› Please refer to [`dotenv-flow.listFiles(options)`](https://github.com/kerimdzhanov/dotenv-flow#listfilesoptions--string) to learn more.
 
 #### `encoding`
 ###### Type: `string`

--- a/lib/dotenv-flow-webpack.js
+++ b/lib/dotenv-flow-webpack.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {DefinePlugin} = require('webpack');
-const { listFiles, parse } = require('dotenv-flow');
+const {DEFAULT_PATTERN, listFiles, parse} = require('dotenv-flow');
 
 class DotenvFlow extends DefinePlugin {
   /**
@@ -9,24 +9,27 @@ class DotenvFlow extends DefinePlugin {
    * @param {string} [options.node_env=process.env.NODE_ENV] - node environment (development/test/production/etc,.)
    * @param {string} [options.default_node_env] - the default node environment
    * @param {string} [options.path=process.cwd()] - path to `.env*` files directory
-   * @param {string} [options.encoding='utf8'] - encoding for reading the `.env*` files
+   * @param {string} [options.pattern='.env[.node_env][.local]'] - naming
+   * @param {BufferEncoding|null} [options.encoding='utf8'] - encoding for reading the `.env*` files
    * @param {boolean} [options.system_vars=false] - set to `true` to load all the predefined `process.env.*` variables
    * @param {boolean} [options.silent=false] - set to `true` to suppress all errors and warnings
    */
   constructor(options = {}) {
     const node_env = options.node_env || process.env.NODE_ENV || options.default_node_env;
 
-    const path = options.path || process.cwd();
-    const system_vars = options.system_vars || options.systemvars || false; // allow `options.systemvars` for compatibility with dotenv-webpack's options
-    const silent = options.silent || false;
+    const {
+      path = process.cwd(),
+      pattern = DEFAULT_PATTERN,
+      system_vars = options.systemvars || false // allow `options.systemvars` for compatibility with dotenv-webpack's options
+    } = options;
 
     try {
-      const filenames = listFiles({ node_env, path });
+      const filenames = listFiles({ node_env, path, pattern });
       const variables = parse(filenames, { encoding: options.encoding });
 
       if (system_vars) {
         Object.keys(process.env).forEach((varname) => {
-          if (!silent && variables.hasOwnProperty(varname)) {
+          if (!options.silent && variables.hasOwnProperty(varname)) {
             console.warn(
               'dotenv-flow-webpack: "%s" is overwritten by the system environment variable with the same name',
               varname
@@ -46,7 +49,7 @@ class DotenvFlow extends DefinePlugin {
       super(definitions);
     }
     catch (err) {
-      silent || console.error('dotenv-flow-webpack:', err.message); // >>>
+      options.silent || console.error('dotenv-flow-webpack:', err.message); // >>>
 
       super({});
     }

--- a/test/dotenv-flow-webpack.spec.js
+++ b/test/dotenv-flow-webpack.spec.js
@@ -344,6 +344,35 @@ describe('dotenv-flow-webpack', () => {
     });
   });
 
+  describe('when `options.pattern` is given', () => {
+    let options;
+
+    beforeEach('setup `options.pattern`', () => {
+      options = { pattern: '.env/[local/]env[.node_env]' };
+    });
+
+    it('reads files by the given `.env*` files naming convention', () => {
+      mockFS({
+        '/path/to/project/.env/env': 'DEFAULT_ENV_VAR=ok',
+        '/path/to/project/.env/env.development': 'DEVELOPMENT_ENV_VAR=ok',
+        '/path/to/project/.env/local/env': 'LOCAL_ENV_VAR=ok',
+        '/path/to/project/.env/local/env.development': 'LOCAL_DEVELOPMENT_ENV_VAR=ok'
+      });
+
+      process.env.NODE_ENV = 'development';
+
+      const plugin = new DotenvFlow(options);
+
+      expect(plugin.definitions)
+        .to.deep.equal({
+          'process.env.DEFAULT_ENV_VAR': JSON.stringify('ok'),
+          'process.env.LOCAL_ENV_VAR': JSON.stringify('ok'),
+          'process.env.DEVELOPMENT_ENV_VAR': JSON.stringify('ok'),
+          'process.env.LOCAL_DEVELOPMENT_ENV_VAR': JSON.stringify('ok')
+        });
+    });
+  });
+
   describe('when `options.encoding` is given', () => {
     let options;
 


### PR DESCRIPTION
### Summary

This PR introduces a new configuration option `pattern`. It allows users to define a custom naming convention for `.env*` files that *dotenv-flow-webpack* will read.

The default value for the `pattern` option is `".env[.node_env][.local]"` which is fully backward-compatible with the current *dotenv-flow*'s naming convention.

### Description

`options.pattern` allows you to change the default `.env*` files' naming convention if you want to have a specific file naming structure for maintaining your environment variables' files.

#### Default Value

The default value `".env[.node_env][.local]"` makes *dotenv-flow-webpack* look up and load the following files in order:

1. `.env`
2. `.env.local`
3. `.env.${NODE_ENV}`
4. `.env.${NODE_ENV}.local`

For example, when the `proess.env.NODE_ENV` (or `options.node_env`) is set to `"development"`, *dotenv-flow-webpack* will be looking for and parsing (if found) the following files:

1. `.env`
2. `.env.local`
3. `.env.development`
4. `.env.development.local`

#### Custom Patterns

Here are a couple of examples of customizing the `.env*` files naming convention:

For example, if you set the pattern to `".env/[local/]env[.node_env]"`, *dotenv-flow-webpack* will look for these files instead:

1. `.env/env`
2. `.env/local/env`
3. `.env/env.development`
4. `.env/local/env.development`

… or if you set the pattern to `".env/[.node_env/].env[.node_env][.local]"`, the plugin will try to find and parse:

1. `.env/.env`
2. `.env/.env.local`
3. `.env/development/.env.development`
4. `.env/development/.env.development.local`

› Please refer to [`dotenv-flow.listFiles(options)`](https://github.com/kerimdzhanov/dotenv-flow#listfilesoptions--string) to learn more.