### PR TITLE
feat(dotenv-flow-webpack): add debug messaging (available via `options.debug`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ new DotenvFlow({
 })
 ```
 
+#### `options.debug`
+###### Type: `boolean`
+###### Default: `false`
+
+Enables detailed logging to debug why certain variables are not being set as you expect.
+
+```js
+new DotenvFlow({
+  debug: true
+})
+```
+
 #### `silent`
 ###### Type: `boolean`
 ###### Default: `false`

--- a/lib/dotenv-flow-webpack.js
+++ b/lib/dotenv-flow-webpack.js
@@ -2,6 +2,56 @@
 
 const {DefinePlugin} = require('webpack');
 const {DEFAULT_PATTERN, listFiles, parse} = require('dotenv-flow');
+const {version} = require('../package.json');
+
+/**
+ * Returns effective (computed) `node_env`.
+ *
+ * @param {object} options
+ * @param {string} [options.node_env]
+ * @param {string} [options.default_node_env]
+ * @param {boolean} [options.debug]
+ * @return {string|undefined} node_env
+ */
+function getEffectiveNodeEnv(options) {
+  if (options.node_env) {
+    options.debug && debug(
+      `building for "${options.node_env}" environment (set by \`options.node_env\`)`
+    );
+    return options.node_env;
+  }
+
+  if (process.env.NODE_ENV) {
+    options.debug && debug(
+      `building for "${process.env.NODE_ENV}" environment (as per \`process.env.NODE_ENV\`)`
+    );
+    return process.env.NODE_ENV;
+  }
+
+  if (options.default_node_env) {
+    options.debug && debug(
+      `building for "${options.default_node_env}" environment (taken from \`options.default_node_env\`)`
+    );
+    return options.default_node_env;
+  }
+
+  options.debug && debug(
+    'building in "no environment" mode (no environment-related options are set)'
+  );
+
+  return undefined;
+}
+
+const CONFIG_OPTION_KEYS = [
+  'node_env',
+  'default_node_env',
+  'path',
+  'pattern',
+  'encoding',
+  'system_vars',
+  'systemvars',
+  'silent'
+];
 
 class DotenvFlow extends DefinePlugin {
   /**
@@ -12,10 +62,19 @@ class DotenvFlow extends DefinePlugin {
    * @param {string} [options.pattern='.env[.node_env][.local]'] - naming
    * @param {BufferEncoding|null} [options.encoding='utf8'] - encoding for reading the `.env*` files
    * @param {boolean} [options.system_vars=false] - set to `true` to load all the predefined `process.env.*` variables
-   * @param {boolean} [options.silent=false] - set to `true` to suppress all errors and warnings
+   * @param {boolean} [options.debug=false] - turn on detailed logging to help debug why certain variables are not being set as you expect
+   * @param {boolean} [options.silent=false] - suppress all kinds of warnings including ".env*" files' loading errors
    */
   constructor(options = {}) {
-    const node_env = options.node_env || process.env.NODE_ENV || options.default_node_env;
+    if (options.debug) {
+      debug('initializing…');
+
+      CONFIG_OPTION_KEYS
+        .filter(key => key in options)
+        .forEach(key => debug(`| options.${key} =`, options[key]));
+    }
+
+    const node_env = getEffectiveNodeEnv(options);
 
     const {
       path = process.cwd(),
@@ -24,27 +83,33 @@ class DotenvFlow extends DefinePlugin {
     } = options;
 
     try {
-      const filenames = listFiles({ node_env, path, pattern });
-      const variables = parse(filenames, { encoding: options.encoding });
+      const filenames = listFiles({ node_env, path, pattern, debug: options.debug });
+      const variables = parse(filenames, { encoding: options.encoding, debug: options.debug });
 
       if (system_vars) {
-        Object.keys(process.env).forEach((varname) => {
-          if (!options.silent && variables.hasOwnProperty(varname)) {
-            console.warn(
-              'dotenv-flow-webpack: "%s" is overwritten by the system environment variable with the same name',
+        options.debug && debug('registering system environment variables…');
+
+        for (const varname of Object.keys(process.env)) {
+          if (options.debug && variables.hasOwnProperty(varname)) {
+            debug(
+              '`process.env.%s` is overwritten by system-defined environment variable `%s`',
+              varname,
               varname
-            ); // >>>
+            );
           }
 
           variables[varname] = process.env[varname];
-        });
+        }
       }
 
       const definitions = {};
 
-      Object.keys(variables).forEach((varname) => {
+      options.debug && debug("registering environment variables' definitions…");
+
+      for (const varname of Object.keys(variables)) {
+        options.debug && debug('>> process.env.%s', varname);
         definitions[`process.env.${varname}`] = JSON.stringify(variables[varname]);
-      });
+      }
 
       super(definitions);
     }
@@ -53,7 +118,13 @@ class DotenvFlow extends DefinePlugin {
 
       super({});
     }
+
+    options.debug && debug('initialization completed.');
   }
+}
+
+function debug(message, ...values) {
+  console.debug(`[dotenv-flow-webpack@${version}]: ${message}`, ...values);
 }
 
 module.exports = DotenvFlow;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
   },
   "dependencies": {
-    "dotenv-flow": "^4.0.0-rc.2"
+    "dotenv-flow": "^4.0.0-rc.3"
   },
   "devDependencies": {
     "@types/sinon-chai": "^3.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -761,10 +761,10 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv-flow@^4.0.0-rc.2:
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/dotenv-flow/-/dotenv-flow-4.0.0-rc.2.tgz#2c8a83fbe8959b798790837dd12b24cb2b8891c7"
-  integrity sha512-jNIElEs9+I3clIh669BK9P3+uUMKsulj/S9uMNTQkFB+jXkxmqMEaJm/55CtTp7Gkd9WCo5PIXeYVAjBx5J8IQ==
+dotenv-flow@^4.0.0-rc.3:
+  version "4.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/dotenv-flow/-/dotenv-flow-4.0.0-rc.3.tgz#6d26efa44a7ec662e065d411696d48a0ba28bf4b"
+  integrity sha512-vCJqc36kUmIgwluDNkLnIPYB3qvLELUzUxVr91s3gvhtl2WKP9DKigEGrH97KaAj1TEpgJXYCqZ7jP94TLiBnw==
   dependencies:
     dotenv "^16.0.0"
 


### PR DESCRIPTION
This PR adds informative (yet secure) "debug" messages which adds more clarity on what's happening "under the plugin's hood" in certain scenarios and set of options.

Debug messages can be enabled via `options.debug`.