### PR TITLE
feat!: throw on failures

### DIFF
--- a/lib/dotenv-flow-webpack.js
+++ b/lib/dotenv-flow-webpack.js
@@ -82,42 +82,35 @@ class DotenvFlow extends DefinePlugin {
       system_vars = options.systemvars || false // allow `options.systemvars` for compatibility with dotenv-webpack's options
     } = options;
 
-    try {
-      const filenames = listFiles({ node_env, path, pattern, debug: options.debug });
-      const variables = parse(filenames, { encoding: options.encoding, debug: options.debug });
+    const filenames = listFiles({ node_env, path, pattern, debug: options.debug });
+    const variables = parse(filenames, { encoding: options.encoding, debug: options.debug });
 
-      if (system_vars) {
-        options.debug && debug('registering system environment variables…');
+    if (system_vars) {
+      options.debug && debug('registering system environment variables…');
 
-        for (const varname of Object.keys(process.env)) {
-          if (options.debug && variables.hasOwnProperty(varname)) {
-            debug(
-              '`process.env.%s` is overwritten by system-defined environment variable `%s`',
-              varname,
-              varname
-            );
-          }
-
-          variables[varname] = process.env[varname];
+      for (const varname of Object.keys(process.env)) {
+        if (options.debug && variables.hasOwnProperty(varname)) {
+          debug(
+            '`process.env.%s` is overwritten by system-defined environment variable `%s`',
+            varname,
+            varname
+          );
         }
+
+        variables[varname] = process.env[varname];
       }
-
-      const definitions = {};
-
-      options.debug && debug("registering environment variables' definitions…");
-
-      for (const varname of Object.keys(variables)) {
-        options.debug && debug('>> process.env.%s', varname);
-        definitions[`process.env.${varname}`] = JSON.stringify(variables[varname]);
-      }
-
-      super(definitions);
     }
-    catch (err) {
-      options.silent || console.error('dotenv-flow-webpack:', err.message); // >>>
 
-      super({});
+    const definitions = {};
+
+    options.debug && debug("registering environment variables' definitions…");
+
+    for (const varname of Object.keys(variables)) {
+      options.debug && debug('>> process.env.%s', varname);
+      definitions[`process.env.${varname}`] = JSON.stringify(variables[varname]);
     }
+
+    super(definitions);
 
     options.debug && debug('initialization completed.');
   }

--- a/test/dotenv-flow-webpack.spec.js
+++ b/test/dotenv-flow-webpack.spec.js
@@ -885,37 +885,9 @@ describe('dotenv-flow-webpack', () => {
         .throws(new Error('`.env.local` file reading error stub'));
     });
 
-    let $consoleError;
-
-    beforeEach('stub `console.error`', () => {
-      $consoleError = sinon.stub(console, 'error');
-    });
-
-    afterEach(() => $consoleError.restore());
-
-    it('prints the occurred error via `console.error()`', () => {
-      new DotenvFlow();
-
-      expect($consoleError)
-        .to.have.been.calledWith(
-          'dotenv-flow-webpack:',
-          '`.env.local` file reading error stub'
-        );
-    });
-
-    describe('… and `options.silent` is enabled', () => {
-      let options;
-
-      beforeEach('setup `options.silent`', () => {
-        options = { silent: true };
-      });
-
-      it("doesn't print any errors", () => {
-        new DotenvFlow(options);
-
-        expect($consoleError)
-          .to.have.not.been.called;
-      });
+    it('throws the occurred error', () => {
+      expect(() => new DotenvFlow())
+        .to.throw('`.env.local` file reading error stub');
     });
   });
 });


### PR DESCRIPTION
This CR changes the behaviour of the plugin to throw exceptions instead of logging them as errors.

BREAKING CHANGE: the plugin is now throwing exceptions on `.env*` file reading/parsing failures instead of "error logging" them.