### PR TITLE
feat: warn if none of the appropriate `.env*` files is found

### DIFF
--- a/lib/dotenv-flow-webpack.js
+++ b/lib/dotenv-flow-webpack.js
@@ -5,6 +5,15 @@ const {DEFAULT_PATTERN, listFiles, parse} = require('dotenv-flow');
 const {version} = require('../package.json');
 
 /**
+ * The `[.node_env]` placeholder regex.
+ *
+ * › taken from https://github.com/kerimdzhanov/dotenv-flow/blob/master/lib/dotenv-flow.js#L11
+ *
+ * @type {RegExp}
+ */
+const NODE_ENV_PLACEHOLDER_REGEX = /\[(\W*\b)node_env(\b\W*)]/g;
+
+/**
  * Returns effective (computed) `node_env`.
  *
  * @param {object} options
@@ -83,6 +92,22 @@ class DotenvFlow extends DefinePlugin {
     } = options;
 
     const filenames = listFiles({ node_env, path, pattern, debug: options.debug });
+
+    if (filenames.length === 0) {
+      if (!options.silent) {
+        const _pattern = node_env
+          ? pattern.replace(NODE_ENV_PLACEHOLDER_REGEX, `[$1${node_env}$2]`)
+          : pattern;
+
+        warn(
+          '`.env*` files loading failed',
+          `no ".env*" files matching pattern "${_pattern}" found in "${path}" dir`
+        );
+      }
+
+      return super();
+    }
+
     const variables = parse(filenames, { encoding: options.encoding, debug: options.debug });
 
     if (system_vars) {
@@ -118,6 +143,14 @@ class DotenvFlow extends DefinePlugin {
 
 function debug(message, ...values) {
   console.debug(`[dotenv-flow-webpack@${version}]: ${message}`, ...values);
+}
+
+function warn(message, reason) {
+  if (reason) {
+    message += ': %s';
+  }
+
+  console.warn(`[dotenv-flow-webpack@${version}]: ${message}`, reason);
 }
 
 module.exports = DotenvFlow;


### PR DESCRIPTION
This PR adds a warning about missing files that will be printed if none of the appropriate `.env` files is present.